### PR TITLE
Update WLPManagedContainer.java

### DIFF
--- a/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
+++ b/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
@@ -870,7 +870,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
            final boolean writeOutput = containerConfiguration.isOutputToConsole();
 
            try {
-               byte[] buf = new byte[32];
+               byte[] buf = new byte[32000];
                int num;
                // Do not try reading a line cos it considers '\r' end of line
                while ((num = stream.read(buf)) != -1) {


### PR DESCRIPTION
increase read buffer size to prevent deadlock with noisy tests.

